### PR TITLE
Replacement of APM usage (Begin/EndGetResponse, etc.) with TAP (GetResponseAsync) and async/await

### DIFF
--- a/Ocell.Library/Ocell.Library/Ocell.Library.csproj
+++ b/Ocell.Library/Ocell.Library/Ocell.Library.csproj
@@ -20,6 +20,8 @@
     <ThrowErrorsInValidation>true</ThrowErrorsInValidation>
     <Utf8Output>true</Utf8Output>
     <ExpressionBlendVersion>4.0.30816.0</ExpressionBlendVersion>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -68,7 +70,13 @@
     <Reference Include="Newtonsoft.Json.WindowsPhone">
       <HintPath>..\..\Ocell.ThirdParty\lib_dll\Newtonsoft.Json.WindowsPhone.dll</HintPath>
     </Reference>
+    <Reference Include="System.Runtime">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.0.19\lib\sl4-windowsphone71\System.Runtime.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Threading.Tasks">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.0.19\lib\sl4-windowsphone71\System.Threading.Tasks.dll</HintPath>
+    </Reference>
     <Reference Include="System.Windows" />
     <Reference Include="system" />
     <Reference Include="System.Core" />
@@ -212,6 +220,7 @@
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\Silverlight for Phone\$(TargetFrameworkVersion)\Microsoft.Silverlight.$(TargetFrameworkProfile).Overrides.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\Silverlight for Phone\$(TargetFrameworkVersion)\Microsoft.Silverlight.CSharp.targets" />
   <ProjectExtensions />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Ocell.Library/Ocell.Library/PushNotifications.cs
+++ b/Ocell.Library/Ocell.Library/PushNotifications.cs
@@ -171,7 +171,7 @@ namespace Ocell
         }
 
         [Conditional("OCELL_FULL")]
-        static void SendRemoveRequestToServer(UserToken token, string type)
+        static async void SendRemoveRequestToServer(UserToken token, string type)
         {
             string encoded = Library.Encrypting.EncodeTokens(token.Key, token.Secret);
             string url = string.Format(Library.SensitiveData.PushUnregisterUriFormat, Uri.EscapeDataString(encoded), type);
@@ -180,9 +180,7 @@ namespace Ocell
 
             try
             {
-                var response = request.BeginGetResponse((result) =>
-                {
-                }, request);
+                var response = await request.GetResponseAsync();
             }
             catch (Exception)
             {

--- a/Ocell.Library/Ocell.Library/Tasks/Scheduler.cs
+++ b/Ocell.Library/Ocell.Library/Tasks/Scheduler.cs
@@ -22,7 +22,7 @@ namespace Ocell.Library.Tasks
         }
 
         [Conditional("OCELL_FULL")]
-        public void ScheduleTweet(string text, DateTime dueTime, RequestCallback callback)
+        public async void ScheduleTweet(string text, DateTime dueTime, RequestCallback callback)
         {
             TimeSpan diff = dueTime - DateTime.Now;
             long delay = (long)diff.TotalMilliseconds;
@@ -30,23 +30,19 @@ namespace Ocell.Library.Tasks
             string url = String.Format(SensitiveData.ScheduleUriformat, Uri.EscapeDataString(accessToken), Uri.EscapeDataString(text), delay);
 
             var request = (HttpWebRequest)WebRequest.Create(url);
-
-            request.BeginGetResponse((result) =>
+            
+            HttpWebResponse response;
+            try
             {
-                HttpWebResponse response;
-
-                try
-                {
-                    response = (HttpWebResponse)request.EndGetResponse(result);
-                }
-                catch (WebException e)
-                {
-                    response = (HttpWebResponse)e.Response;
-                }
-
-                if (callback != null)
+                response = (HttpWebResponse)await request.GetResponseAsync();
+            }
+            catch (WebException e)
+            {
+                response = (HttpWebResponse)e.Response;
+            }
+            
+            if (callback != null)
                     callback(this, response);
-            }, callback);
         }
     }
 

--- a/Ocell.Library/Ocell.Library/packages.config
+++ b/Ocell.Library/Ocell.Library/packages.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Bcl" version="1.0.19" targetFramework="wp71" />
+  <package id="Microsoft.Bcl.Async" version="1.0.16" targetFramework="wp71" />
+  <package id="Microsoft.Bcl.Build" version="1.0.10" targetFramework="wp71" />
   <package id="SharpSerializer" version="2.18" targetFramework="sl40-wp71" />
   <package id="WPtoolkit" version="4.2012.10.30" targetFramework="sl40-wp71" />
 </packages>

--- a/Ocell.UI/Ocell.Phone7/Ocell.Phone7.csproj
+++ b/Ocell.UI/Ocell.Phone7/Ocell.Phone7.csproj
@@ -26,6 +26,8 @@
     <ThrowErrorsInValidation>true</ThrowErrorsInValidation>
     <Utf8Output>true</Utf8Output>
     <ExpressionBlendVersion>5.0.40218.0</ExpressionBlendVersion>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -91,6 +93,12 @@
       <HintPath>..\..\packages\Newtonsoft.Json.5.0.5\lib\portable-net40+sl4+wp7+win8\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Device" />
+    <Reference Include="System.Runtime">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.0.19\lib\sl4-windowsphone71\System.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.0.19\lib\sl4-windowsphone71\System.Threading.Tasks.dll</HintPath>
+    </Reference>
     <Reference Include="System.Windows" />
     <Reference Include="system" />
     <Reference Include="System.Core" />
@@ -575,4 +583,5 @@
   </Target>
   -->
   <ProjectExtensions />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
 </Project>

--- a/Ocell.UI/Ocell.Phone7/Pages/Settings/CouponCodesModel.cs
+++ b/Ocell.UI/Ocell.Phone7/Pages/Settings/CouponCodesModel.cs
@@ -39,7 +39,7 @@ namespace Ocell.Pages.Settings
             Code = "";
         }
 
-        void ValidateCode(object param)
+        async void ValidateCode(object param)
         {
             if (String.IsNullOrWhiteSpace(Code))
             {
@@ -53,32 +53,30 @@ namespace Ocell.Pages.Settings
 
             IsLoading = true;
             validate.RaiseCanExecuteChanged();
-            request.BeginGetResponse((result) =>
-            {
-                bool failed = false; // Easy, no need to complicate here
-                HttpWebResponse response = null;
-                try
-                {
-                    response = (HttpWebResponse)request.EndGetResponse(result);
-                }
-                catch (Exception)
-                {
-                    failed = true;
-                }
 
-                IsLoading = false;
-                validate.RaiseCanExecuteChanged();
-                if (failed || response.StatusCode != HttpStatusCode.OK)
-                {
-                    MessageService.ShowError(Resources.CodeInvalid);
-                }
-                else
-                {
-                    Config.CouponCodeValidated = true;
-                    MessageService.ShowMessage(Resources.CodeValid);
-                    GoBack();
-                }
-            }, null);
+            HttpWebResponse response;
+            bool failed=false;
+            try
+            {
+                response= (HttpWebResponse) await request.GetResponseAsync();
+            }
+            catch (Exception)
+            {
+                failed = true;
+            }
+
+            IsLoading = false;
+            validate.RaiseCanExecuteChanged();
+            if (failed || response.StatusCode != HttpStatusCode.OK)
+            {
+                MessageService.ShowError(Resources.CodeInvalid);
+            }
+            else
+            {
+                Config.CouponCodeValidated = true;
+                MessageService.ShowMessage(Resources.CodeValid);
+                GoBack();
+            }
         }
     }
 }

--- a/Ocell.UI/Ocell.Phone7/packages.config
+++ b/Ocell.UI/Ocell.Phone7/packages.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Bcl" version="1.0.19" targetFramework="wp71" />
+  <package id="Microsoft.Bcl.Async" version="1.0.16" targetFramework="wp71" />
+  <package id="Microsoft.Bcl.Build" version="1.0.10" targetFramework="wp71" />
   <package id="Newtonsoft.Json" version="5.0.5" targetFramework="wp71" />
   <package id="PhoneThemeManager" version="1.3.2" targetFramework="wp71" />
   <package id="WPtoolkit" version="4.2012.10.30" targetFramework="wp71" />


### PR DESCRIPTION
As part of a research project at the University of Illinois at Urbana-Champaign, we're developing a refactoring tool that replaces instances of the APM pattern with corresponding TAP method calls and the async/await keywords. I've applied it to this project.

This pull request replaces those existing calls to APM Begin/End\* methods with functionally equivalent TAP constructs and the async/await keywords.

I also added a dependency that is needed: Microsoft.Bcl.Async by Microsoft. This package improves support for async/await-based programming for older frameworks, or frameworks that are missing functionality (for WP, specifically, TAP extension methods for WebRequest).

Are you interested in merging this pull request? If not, please let me know why, and I'll try and improve the pull request with your comments in mind.

Thanks for your time,
Semih Okur
